### PR TITLE
Change build script to create 404 page

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
             - run:
                   name: test & build
                   command: npm run test && npm run build
-            - store_test_results
+            
             - run: mkdir -p workspace
             - run: cp -r ./build ./workspace && cd workspace && ls
               # Persist the specified paths (workspace/echo-output) into the workspace for use in downstream job.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,8 @@ jobs:
             - run:
                   name: test & build
                   command: npm run test && npm run build
-            - run:
-                  name: check folder
-                  command: ls
+            - store_test_results:
+                path: test-results
             - run: mkdir -p workspace
             - run: cp -r ./build ./workspace && cd workspace && ls
               # Persist the specified paths (workspace/echo-output) into the workspace for use in downstream job.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,7 @@ jobs:
             - run:
                   name: test & build
                   command: npm run test && npm run build
-            - store_test_results:
-                path: test-results
+            - store_test_results
             - run: mkdir -p workspace
             - run: cp -r ./build ./workspace && cd workspace && ls
               # Persist the specified paths (workspace/echo-output) into the workspace for use in downstream job.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     },
     "scripts": {
         "start": "react-scripts start",
-        "build": "react-scripts build && npx eslint --fix .",
+        "build": "react-scripts build && npx eslint --fix . && cp build/index.html build/404.html",
         "test": "react-scripts test",
         "eject": "react-scripts eject",
         "build:analyze": "webpack --mode production --env analyze",

--- a/src/components/LoginModal/LoginModal.test.tsx
+++ b/src/components/LoginModal/LoginModal.test.tsx
@@ -1,8 +1,11 @@
 import "@testing-library/jest-dom";
 import {render, screen} from "@testing-library/react";
+import { MemoryRouter } from "react-router";
 import LoginModal from "./LoginModal";
 
 test("renders Login Modal", () => {
-  render(<LoginModal />);
+  render( <MemoryRouter>
+    <LoginModal />
+  </MemoryRouter>);
   expect(screen.getByText("Sign in to Planthor"));
 });

--- a/src/components/NavigationBar/NavigationBar.test.tsx
+++ b/src/components/NavigationBar/NavigationBar.test.tsx
@@ -1,8 +1,12 @@
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
 import NavigationBar from "./NavigationBar";
 
 test("This is Navigation bar", () => {
-  render(<NavigationBar />);
+  render(
+  <MemoryRouter>
+    <NavigationBar />
+  </MemoryRouter>);
   expect(screen.getByText("Menu"));
 });

--- a/src/pages/ComponentWidget/ComponentWidget.test.tsx
+++ b/src/pages/ComponentWidget/ComponentWidget.test.tsx
@@ -1,8 +1,11 @@
 import "@testing-library/jest-dom";
 import {render, screen} from "@testing-library/react";
+import { MemoryRouter } from "react-router";
 import ComponentWidget from "./ComponentWidget";
 
 test("renders ComponentWidget page", () => {
-  render(<ComponentWidget />);
+  render( <MemoryRouter>
+    <ComponentWidget />
+  </MemoryRouter>);
   expect(screen.getByText("This is an ComponentWidget Page")).toBeInTheDocument();
 });

--- a/src/pages/Login/Login.test.tsx
+++ b/src/pages/Login/Login.test.tsx
@@ -1,8 +1,11 @@
 import "@testing-library/jest-dom";
 import {render, screen} from "@testing-library/react";
+import { MemoryRouter } from "react-router";
 import Login from "./Login";
 
 test("renders Activity page", () => {
-  render(<Login />);
-  expect(screen.getByAltText("Sign in")).toBeInTheDocument();
+  render( <MemoryRouter>
+    <Login />
+  </MemoryRouter>);
+  expect(screen.getByText("Sign in to Planthor"));
 });


### PR DESCRIPTION
## Resolved issue cant redirect to Login page

### Root cause :

-  Github page cant not detect 404 page in build folder.

### Solution:

- Change script build in  `Package.json` in build script from

```
"build": "react-scripts build && npx eslint --fix ."
```
to 

```
"build": "react-scripts build && npx eslint --fix . && cp build/index.html build/404.html",
```
